### PR TITLE
Pass `attempt_number` in RequestMetadata

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BuildEventServiceGrpcClient.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BuildEventServiceGrpcClient.java
@@ -101,6 +101,7 @@ public class BuildEventServiceGrpcClient implements BuildEventServiceClient {
                       buildRequestId,
                       commandId.toString(),
                       "publish_lifecycle_event",
+                      /* attemptNumber= */ 1,
                       /* actionMetadata= */ null)))
           .publishLifecycleEvent(lifecycleEvent);
     } catch (StatusRuntimeException e) {
@@ -127,6 +128,7 @@ public class BuildEventServiceGrpcClient implements BuildEventServiceClient {
                           buildRequestId,
                           commandId.toString(),
                           "publish_build_tool_event_stream",
+                          /* attemptNumber= */ 1,
                           /* actionMetadata= */ null)))
               .publishBuildToolEventStream(
                   new StreamObserver<PublishBuildToolEventStreamResponse>() {

--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
@@ -396,7 +396,7 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
     }
 
     RequestMetadata metadata =
-        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "bes-upload", null);
+        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "bes-upload", 1, null);
     RemoteActionExecutionContext context =
         RemoteActionExecutionContext.create(metadata)
             .withWriteCachePolicy(CachePolicy.REMOTE_CACHE_ONLY);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -170,7 +170,8 @@ final class RemoteActionContextProvider {
               remoteExecutor,
               tempPathGenerator,
               captureCorruptedOutputsDir,
-              remoteOutputChecker);
+              remoteOutputChecker,
+              env.getAttemptNumber());
       env.getEventBus().register(remoteExecutionService);
     }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -93,7 +93,7 @@ public class RemoteActionInputFetcher extends AbstractActionInputPrefetcher {
       throws IOException {
     checkArgument(metadata.isRemote(), "Cannot download file that is not a remote file.");
     RequestMetadata requestMetadata =
-        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "prefetcher", action);
+        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "prefetcher", 1, action);
     RemoteActionExecutionContext context = RemoteActionExecutionContext.create(requestMetadata);
 
     Digest digest = DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize());

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -589,7 +589,7 @@ public class RemoteExecutionService {
       ActionKey actionKey = digestUtil.computeActionKey(action);
 
       RequestMetadata metadata =
-          TracingMetadataUtils.buildMetadataWithAttemptNumber(
+          TracingMetadataUtils.buildMetadata(
               buildRequestId, commandId, actionKey.getDigest().getHash(), this.attemptNumber, spawn.getResourceOwner());
       RemoteActionExecutionContext remoteActionExecutionContext =
           RemoteActionExecutionContext.create(

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -188,6 +188,8 @@ public class RemoteExecutionService {
 
   @Nullable private final Scrubber scrubber;
 
+  private final int attemptNumber;
+
   public RemoteExecutionService(
       Executor executor,
       Reporter reporter,
@@ -202,7 +204,8 @@ public class RemoteExecutionService {
       @Nullable RemoteExecutionClient remoteExecutor,
       TempPathGenerator tempPathGenerator,
       @Nullable Path captureCorruptedOutputsDir,
-      @Nullable RemoteOutputChecker remoteOutputChecker) {
+      @Nullable RemoteOutputChecker remoteOutputChecker,
+      int attemptNumber) {
     this.reporter = reporter;
     this.verboseFailures = verboseFailures;
     this.execRoot = execRoot;
@@ -213,6 +216,7 @@ public class RemoteExecutionService {
     this.remoteOptions = remoteOptions;
     this.remoteCache = remoteCache;
     this.remoteExecutor = remoteExecutor;
+    this.attemptNumber = attemptNumber;
 
     Caffeine<Object, Object> merkleTreeCacheBuilder = Caffeine.newBuilder().softValues();
     // remoteMerkleTreesCacheSize = 0 means limitless.
@@ -585,8 +589,8 @@ public class RemoteExecutionService {
       ActionKey actionKey = digestUtil.computeActionKey(action);
 
       RequestMetadata metadata =
-          TracingMetadataUtils.buildMetadata(
-              buildRequestId, commandId, actionKey.getDigest().getHash(), spawn.getResourceOwner());
+          TracingMetadataUtils.buildMetadataWithAttemptNumber(
+              buildRequestId, commandId, actionKey.getDigest().getHash(), this.attemptNumber, spawn.getResourceOwner());
       RemoteActionExecutionContext remoteActionExecutionContext =
           RemoteActionExecutionContext.create(
               spawn, metadata, getWriteCachePolicy(spawn), getReadCachePolicy(spawn));

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteLeaseExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteLeaseExtension.java
@@ -87,7 +87,7 @@ public class RemoteLeaseExtension implements LeaseExtension {
     this.remoteCache = remoteCache;
     this.remoteCacheTtl = remoteCacheTtl;
     RequestMetadata requestMetadata =
-        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "lease-extension", null);
+        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "lease-extension", 1, null);
     this.context = RemoteActionExecutionContext.create(requestMetadata);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
@@ -114,7 +114,7 @@ public class RemoteRepositoryRemoteExecutor implements RepositoryRemoteExecutor 
       Duration timeout)
       throws IOException, InterruptedException {
     RequestMetadata metadata =
-        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "repository_rule", null);
+        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "repository_rule", 1, null);
     RemoteActionExecutionContext context = RemoteActionExecutionContext.create(metadata);
 
     Platform platform = PlatformUtils.buildPlatformProto(executionProperties);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
@@ -72,7 +72,7 @@ class RemoteServerCapabilities {
 
   public ListenableFuture<ServerCapabilities> get(ManagedChannel channel) {
     RequestMetadata metadata =
-        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "capabilities", null);
+        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "capabilities", 1, null);
     RemoteActionExecutionContext context = RemoteActionExecutionContext.create(metadata);
     GetCapabilitiesRequest request =
         instanceName == null

--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -120,7 +120,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
       Optional<String> type)
       throws IOException, InterruptedException {
     RequestMetadata metadata =
-        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "remote_downloader", null);
+        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "remote_downloader", 1, null);
     RemoteActionExecutionContext remoteActionExecutionContext =
         RemoteActionExecutionContext.create(metadata);
 

--- a/src/main/java/com/google/devtools/build/lib/remote/util/TracingMetadataUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/TracingMetadataUtils.java
@@ -51,6 +51,7 @@ public class TracingMetadataUtils {
       String buildRequestId,
       String commandId,
       String actionId,
+      int attemptNumber,
       @Nullable ActionExecutionMetadata actionMetadata) {
     Preconditions.checkNotNull(buildRequestId);
     Preconditions.checkNotNull(commandId);
@@ -60,6 +61,7 @@ public class TracingMetadataUtils {
             .setCorrelatedInvocationsId(buildRequestId)
             .setToolInvocationId(commandId)
             .setActionId(actionId)
+            .setAttemptNumber(attemptNumber)
             .setToolDetails(
                 ToolDetails.newBuilder()
                     .setToolName("bazel")
@@ -73,18 +75,6 @@ public class TracingMetadataUtils {
       builder.setConfigurationId(actionMetadata.getOwner().getConfigurationChecksum());
     }
     return builder.build();
-  }
-
-  public static RequestMetadata buildMetadataWithAttemptNumber(
-      String buildRequestId,
-      String commandId,
-      String actionId,
-      int attemptNumber,
-      @Nullable ActionExecutionMetadata actionMetadata) {
-    return buildMetadata(buildRequestId, commandId, actionId, actionMetadata)
-        .toBuilder()
-        .setAttemptNumber(attemptNumber)
-        .build();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/util/TracingMetadataUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/TracingMetadataUtils.java
@@ -75,6 +75,18 @@ public class TracingMetadataUtils {
     return builder.build();
   }
 
+  public static RequestMetadata buildMetadataWithAttemptNumber(
+      String buildRequestId,
+      String commandId,
+      String actionId,
+      int attemptNumber,
+      @Nullable ActionExecutionMetadata actionMetadata) {
+    return buildMetadata(buildRequestId, commandId, actionId, actionMetadata)
+        .toBuilder()
+        .setAttemptNumber(attemptNumber)
+        .build();
+  }
+
   /**
    * Fetches a {@link RequestMetadata} defined on the current context.
    *

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -140,6 +140,7 @@ public class ByteStreamUploaderTest {
             "none",
             "none",
             DIGEST_UTIL.asActionKey(Digest.getDefaultInstance()).getDigest().getHash(),
+            1,
             null);
     context = RemoteActionExecutionContext.create(metadata);
 
@@ -1036,6 +1037,7 @@ public class ByteStreamUploaderTest {
               "build-req-id",
               "command-id",
               DIGEST_UTIL.asActionKey(actionDigest).getDigest().getHash(),
+              1,
               null);
       RemoteActionExecutionContext remoteActionExecutionContext =
           RemoteActionExecutionContext.create(metadata);

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -256,7 +256,7 @@ public class GrpcCacheClientTest {
     outErr = new FileOutErr(stdout, stderr);
     RequestMetadata metadata =
         TracingMetadataUtils.buildMetadata(
-            "none", "none", Digest.getDefaultInstance().getHash(), null);
+            "none", "none", Digest.getDefaultInstance().getHash(), 1, null);
     context = RemoteActionExecutionContext.create(metadata);
     retryService = MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1));
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
@@ -106,7 +106,7 @@ public class RemoteCacheTest {
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
     RequestMetadata metadata =
-        TracingMetadataUtils.buildMetadata("none", "none", "action-id", null);
+        TracingMetadataUtils.buildMetadata("none", "none", "action-id", 1, null);
     Spawn spawn =
         new SimpleSpawn(
             new FakeOwner("foo", "bar", "//dummy:label"),

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -193,7 +193,7 @@ public class RemoteExecutionServiceTest {
     executor = mock(RemoteExecutionClient.class);
 
     RequestMetadata metadata =
-        TracingMetadataUtils.buildMetadata("none", "none", "action-id", null);
+        TracingMetadataUtils.buildMetadata("none", "none", "action-id", 1, null);
     remoteActionExecutionContext = RemoteActionExecutionContext.create(metadata);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -108,6 +108,7 @@ public class GrpcRemoteDownloaderTest {
             "none",
             "none",
             DIGEST_UTIL.asActionKey(Digest.getDefaultInstance()).getDigest().getHash(),
+            1,
             null);
     context = RemoteActionExecutionContext.create(metadata);
 

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -346,7 +346,7 @@ public class HttpCacheClientTest {
     remoteActionExecutionContext =
         RemoteActionExecutionContext.create(
             TracingMetadataUtils.buildMetadata(
-                "none", "none", Digest.getDefaultInstance().getHash(),1, null));
+                "none", "none", Digest.getDefaultInstance().getHash(), 1, null));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -346,7 +346,7 @@ public class HttpCacheClientTest {
     remoteActionExecutionContext =
         RemoteActionExecutionContext.create(
             TracingMetadataUtils.buildMetadata(
-                "none", "none", Digest.getDefaultInstance().getHash(), null));
+                "none", "none", Digest.getDefaultInstance().getHash(),1, null));
   }
 
   @Test

--- a/third_party/remoteapis/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/third_party/remoteapis/build/bazel/remote/execution/v2/remote_execution.proto
@@ -2073,4 +2073,9 @@ message RequestMetadata {
   // There is no expectation that this value will have any particular structure,
   // or equality across invocations, though some client tools may offer these guarantees.
   string configuration_id = 7;
+
+  // If Bazel automatically retries an invocation, this value is set to the
+  // number of invocation attempts that have been started so far. For example, a
+  // value of 2 would indicate that it is the second attempt.
+  int32 attempt_number = 8;
 }


### PR DESCRIPTION
Now that we properly track the `attempt_number` with https://github.com/bazelbuild/bazel/commit/2ab3be22e5d3605673fea6d43783c057be46a2b9, pass the info to the remote execution request metadata as well to indicate whether this action invocation is the Nth attempt.